### PR TITLE
Add when function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.phpunit.result.cache

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -49,6 +49,23 @@ class WorkflowDefinition
         return $this;
     }
 
+    /**
+     * @param  bool          $value
+     * @param  callable      $callback
+     * @param  callable|null $default
+     * @return $this
+     */
+    public function when(bool $value, callable $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
     public function then($callback): self
     {
         $this->thenCallback = $this->serializeCallback($callback);

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -219,6 +219,28 @@ it('returns false if job is not part of the workflow', function () {
     assertFalse($definition->hasJob(TestJob1::class));
 });
 
+it('can conditionally add a job to the workflow with a callback', function () {
+    $definition = WorkflowFacade::define('::name::')
+        ->when(true, 
+            fn($workflow) => $workflow->addJob(new TestJob1()),
+            fn($workflow) => $workflow->addJob(new TestJob2())
+        );
+
+    assertTrue($definition->hasJob(TestJob1::class));
+    assertFalse($definition->hasJob(TestJob2::class));
+});
+
+it('doesnt add a job if the conditional is false', function () {
+    $definition = WorkflowFacade::define('::name::')
+        ->when(false, 
+            fn($workflow) => $workflow->addJob(new TestJob1()),
+            fn($workflow) => $workflow->addJob(new TestJob2())
+        );
+
+    assertFalse($definition->hasJob(TestJob1::class));
+    assertTrue($definition->hasJob(TestJob2::class));
+});
+
 it('returns true if job exists with the correct dependencies', function () {
     $definition = WorkflowFacade::define('::name::')
         ->addJob(new TestJob1())


### PR DESCRIPTION
Similar to Laravel's QueryBuilder::when and Collection::when, the following adds a method that will only execute the callback if the conditional is true.

```php
public function definition($useCache): WorkflowDefinition
{
        return Workflow::define('Build Job')
            ->addJob(new StartBuild($this->build))
            ->when($useCache, fn ($workflow) => $workflow->addJob(DownloadCache($this->build)))
}
```