### PR TITLE
[Draft] Nested workflows

### DIFF
--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -81,6 +81,8 @@ class DependencyGraph
             return [$dependency];
         }
 
+        // Depending on a nested graph means depending on each of the graph's
+        // leaf nodes, i.e. nodes with an out-degree of 0.
         if (array_key_exists($dependency, $this->nestedGraphs)) {
             return collect($this->nestedGraphs[$dependency])
                 ->filter(fn (array $node) => count($node['out_edges']) === 0)

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -5,7 +5,12 @@ namespace Sassnowski\Venture\Graph;
 class DependencyGraph
 {
     private array $unresolvableDependencies = [];
-    private array $graph = [];
+    private array $graph;
+
+    public function __construct(array $graph = [])
+    {
+        $this->graph = $graph;
+    }
 
     public function addDependantJob($job, array $dependencies): void
     {
@@ -58,5 +63,16 @@ class DependencyGraph
     public function getUnresolvableDependencies(): array
     {
         return $this->unresolvableDependencies;
+    }
+
+    public function connectGraph(DependencyGraph $otherGraph, array $dependencies): void
+    {
+        foreach ($otherGraph->graph as $node) {
+            if (count($node['in_edges']) === 0) {
+                $node['in_edges'] = $dependencies;
+            }
+
+            $this->addDependantJob($node['instance'], $node['in_edges']);
+        }
     }
 }

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -60,6 +60,9 @@ class DependencyGraph
         $this->nestedGraphs[$id] = $otherGraph->graph;
 
         foreach ($otherGraph->graph as $node) {
+            // The root nodes of the nested graph should be connected to
+            // the provided dependencies. If the dependency happens to be
+            // another graph, it will be resolved inside `addDependantJob`.
             if (count($node['in_edges']) === 0) {
                 $node['in_edges'] = $dependencies;
             }

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -63,6 +63,19 @@ class WorkflowDefinition
         return $this->addJob($job, $dependencies, $name, $delay);
     }
 
+    public function addWorkflow(AbstractWorkflow $workflow, array $dependencies): self
+    {
+        $definition = $workflow->definition();
+
+        $this->graph->connectGraph($definition->graph, $dependencies);
+
+        foreach ($definition->jobs as $job) {
+            $this->jobs[] = $job;
+        }
+
+        return $this;
+    }
+
     public function then($callback): self
     {
         $this->thenCallback = $this->serializeCallback($callback);

--- a/tests/DependencyGraphTest.php
+++ b/tests/DependencyGraphTest.php
@@ -8,6 +8,7 @@ use Stubs\TestJob5;
 use Stubs\TestJob6;
 use function PHPUnit\Framework\assertEquals;
 use Sassnowski\Venture\Graph\DependencyGraph;
+use Sassnowski\Venture\Exceptions\UnresolvableDependenciesException;
 
 beforeEach(function () {
     $this->graph = new DependencyGraph();
@@ -22,11 +23,15 @@ it('returns no dependencies if a job has none', function () {
 });
 
 it('returns the jobs direct dependencies', function () {
-    $job = new TestJob1();
+    $job1 = new TestJob1();
+    $job2 = new TestJob2();
+    $job3 = new TestJob3();
 
-    $this->graph->addDependantJob($job, ['::dependency-1::', '::dependency-2::']);
+    $this->graph->addDependantJob($job1, []);
+    $this->graph->addDependantJob($job2, [TestJob1::class]);
+    $this->graph->addDependantJob($job3, [TestJob1::class, TestJob2::class]);
 
-    assertEquals(['::dependency-1::', '::dependency-2::'], $this->graph->getDependencies($job));
+    assertEquals([TestJob1::class, TestJob2::class], $this->graph->getDependencies($job3));
 });
 
 it('returns the instances of all dependants of a job', function () {
@@ -34,6 +39,7 @@ it('returns the instances of all dependants of a job', function () {
     $job2 = new TestJob2();
     $job3 = new TestJob3();
 
+    $this->graph->addDependantJob($job2, []);
     $this->graph->addDependantJob($job1, [TestJob2::class]);
     $this->graph->addDependantJob($job3, [TestJob2::class]);
 
@@ -50,26 +56,14 @@ it('returns all jobs without dependencies', function () {
     assertEquals([$job1], $this->graph->getJobsWithoutDependencies());
 });
 
-it('returns an empty array if there are no jobs with unresolvable dependencies', function () {
-    $this->graph->addDependantJob(new TestJob1(), []);
-    $this->graph->addDependantJob(new TestJob2(), []);
+it('throws an exception when trying to add a job with a dependency that does not exist', function () {
+    test()->expectException(UnresolvableDependenciesException::class);
+    test()->expectExceptionMessage(sprintf(
+        'Unable to resolve dependency [%s]. Make sure it was added before declaring it as a dependency.',
+        TestJob1::class
+    ));
 
-    assertEquals([], $this->graph->getUnresolvableDependencies());
-});
-
-it('returns a list of unresolvable dependencies and their dependants', function () {
     $this->graph->addDependantJob(new TestJob2(), [TestJob1::class]);
-
-    assertEquals([
-        TestJob1::class => [TestJob2::class],
-    ], $this->graph->getUnresolvableDependencies());
-});
-
-it('can register jobs with dependencies before their dependencies are registered', function () {
-    $this->graph->addDependantJob(new TestJob2(), [TestJob1::class]);
-    $this->graph->addDependantJob(new TestJob1(), []);
-
-    assertEquals([], $this->graph->getUnresolvableDependencies());
 });
 
 it('can connect another graph to a single dependency in the current graph', function () {
@@ -108,26 +102,12 @@ it('can connect another graph to a single dependency in the current graph', func
         ],
     ]);
 
-    $graph1->connectGraph($graph2, [TestJob1::class]);
+    $graph1->connectGraph($graph2, '::id::', [TestJob1::class]);
 
     assertEquals([TestJob1::class], $graph1->getDependencies(TestJob4::class));
     assertEquals([TestJob4::class], $graph1->getDependencies(TestJob5::class));
     assertEquals([TestJob1::class], $graph1->getDependencies(TestJob6::class));
     assertEquals([$job2, $job4, $job6], $graph1->getDependantJobs(TestJob1::class));
-});
-
-it('can connect another graph before the connection point was added', function () {
-    $graph1 = new DependencyGraph();
-    $graph2 = new DependencyGraph([
-        TestJob4::class => [
-            'instance' => new TestJob4(),
-            'in_edges' => [],
-            'out_edges' => [],
-        ],
-    ]);
-
-    $graph1->connectGraph($graph2, [TestJob1::class]);
-    assertEquals([TestJob1::class], array_keys($graph1->getUnresolvableDependencies()));
 });
 
 it('can connect a graph to multiple dependencies in the current graph', function () {
@@ -166,7 +146,7 @@ it('can connect a graph to multiple dependencies in the current graph', function
         ],
     ]);
 
-    $graph1->connectGraph($graph2, [TestJob2::class, TestJob3::class]);
+    $graph1->connectGraph($graph2, '::id::', [TestJob2::class, TestJob3::class]);
 
     assertEquals([TestJob2::class, TestJob3::class], $graph1->getDependencies(TestJob4::class));
     assertEquals([TestJob2::class, TestJob3::class], $graph1->getDependencies(TestJob6::class));
@@ -188,7 +168,39 @@ it('can add a different graph without dependencies', function () {
         ],
     ]);
 
-    $graph1->connectGraph($graph2, []);
+    $graph1->connectGraph($graph2, '::id::', []);
 
     assertEquals([$job1, $job2], $graph1->getJobsWithoutDependencies());
+});
+
+it('can add a job with a dependency on a nested workflow', function () {
+    $graph1 = new DependencyGraph([
+        TestJob1::class => [
+            'instance' => new TestJob1(),
+            'in_edges' => [],
+            'out_edges' => [],
+        ],
+    ]);
+    $graph2 = new DependencyGraph([
+        TestJob2::class => [
+            'instance' => new TestJob2(),
+            'in_edges' => [],
+            'out_edges' => [TestJob4::class],
+        ],
+        TestJob3::class => [
+            'instance' => new TestJob3(),
+            'in_edges' => [],
+            'out_edges' => [],
+        ],
+        TestJob4::class => [
+            'instance' => new TestJob4(),
+            'in_edges' => [TestJob2::class],
+            'out_edges' => [],
+        ],
+    ]);
+    $graph1->connectGraph($graph2, '::workflow-id::', [TestJob1::class]);
+
+    $graph1->addDependantJob(new TestJob5(), ['::workflow-id::']);
+
+    assertEquals([TestJob3::class, TestJob4::class], $graph1->getDependencies(TestJob5::class));
 });

--- a/tests/DependencyGraphTest.php
+++ b/tests/DependencyGraphTest.php
@@ -204,3 +204,48 @@ it('can add a job with a dependency on a nested workflow', function () {
 
     assertEquals([TestJob3::class, TestJob4::class], $graph1->getDependencies(TestJob5::class));
 });
+
+it('can add a nested workflow with a dependency on another nested workflow', function () {
+    $graph1 = new DependencyGraph([]);
+    $graph2 = new DependencyGraph([
+        TestJob1::class => [
+            'instance' => new TestJob1(),
+            'in_edges' => [],
+            'out_edges' => [TestJob3::class],
+        ],
+        TestJob2::class => [
+            'instance' => new TestJob2(),
+            'in_edges' => [],
+            'out_edges' => [],
+        ],
+        TestJob3::class => [
+            'instance' => new TestJob3(),
+            'in_edges' => [TestJob1::class],
+            'out_edges' => [],
+        ],
+    ]);
+    $graph3 = new DependencyGraph([
+        TestJob4::class => [
+            'instance' => new TestJob4(),
+            'in_edges' => [],
+            'out_edges' => [TestJob5::class],
+        ],
+        TestJob5::class => [
+            'instance' => new TestJob5(),
+            'in_edges' => [TestJob4::class],
+            'out_edges' => [],
+        ],
+        TestJob6::class => [
+            'instance' => new TestJob6(),
+            'in_edges' => [],
+            'out_edges' => [],
+        ]
+    ]);
+    $graph1->connectGraph($graph2, '::graph-2-id::', []);
+
+    $graph1->connectGraph($graph3, '::graph-3-id::', ['::graph-2-id::']);
+
+    assertEquals([TestJob2::class, TestJob3::class], $graph1->getDependencies(TestJob4::class));
+    assertEquals([TestJob4::class], $graph1->getDependencies(TestJob5::class));
+    assertEquals([TestJob2::class, TestJob3::class], $graph1->getDependencies(TestJob6::class));
+});

--- a/tests/Stubs/TestJob4.php
+++ b/tests/Stubs/TestJob4.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Stubs;
+
+use Illuminate\Bus\Queueable;
+use Sassnowski\Venture\WorkflowStep;
+
+class TestJob4
+{
+    use Queueable, WorkflowStep;
+}

--- a/tests/Stubs/TestJob5.php
+++ b/tests/Stubs/TestJob5.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Stubs;
+
+use Illuminate\Bus\Queueable;
+use Sassnowski\Venture\WorkflowStep;
+
+class TestJob5
+{
+    use Queueable, WorkflowStep;
+}

--- a/tests/Stubs/TestJob6.php
+++ b/tests/Stubs/TestJob6.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Stubs;
+
+use Illuminate\Bus\Queueable;
+use Sassnowski\Venture\WorkflowStep;
+
+class TestJob6
+{
+    use Queueable, WorkflowStep;
+}

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -17,7 +17,6 @@ use function PHPUnit\Framework\assertFalse;
 use function Pest\Laravel\assertDatabaseHas;
 use function PHPUnit\Framework\assertEquals;
 use Sassnowski\Venture\Facades\Workflow as WorkflowFacade;
-use Sassnowski\Venture\Exceptions\UnresolvableDependenciesException;
 
 uses(TestCase::class);
 
@@ -266,21 +265,6 @@ dataset('delay provider', [
     'integer' => [2000],
     'date interval' => [new DateInterval('P14D')],
 ]);
-
-it('throws an exception when trying to build a workflow with unresolvable dependencies', function () {
-    test()->expectException(UnresolvableDependenciesException::class);
-    test()->expectExceptionMessage(sprintf(
-        'Workflow contains unresolvable dependency "%s", depended on by [%s, %s]',
-        TestJob1::class,
-        TestJob2::class,
-        TestJob3::class
-    ));
-
-    WorkflowFacade::define('Invalid Workflow')
-        ->addJob(new TestJob2(), [TestJob1::class])
-        ->addJob(new TestJob3(), [TestJob1::class])
-        ->build();
-});
 
 it('calls the before create hook before saving the workflow if provided', function () {
     $callback = function (Workflow $workflow) {


### PR DESCRIPTION
This PR aims to add support for nested workflows. In other words it allows you add a workflow as a "step" inside another workflow.

```php
public function definition(): WorkflowDefinition
{
    Workflow::define('Workflow name')
        ->addJob(new TestJob1())
        ->addWorkflow(new OtherWorkflow(), [TestJob1::class]);
}
```

This would add all jobs of `OtherWorkflow` to the workflow and connect them properly. Specifically it means that it will connect all jobs with an in-degree of 0 (in other words, jobs without dependency) to the provided dependencies in the parent workflow.

Visually, this means that given the following workflows 

**Workflow A**
![1](https://user-images.githubusercontent.com/5139098/99662383-70f37900-2a65-11eb-8948-47ffa3fc088e.png)

**Workflow B**
![2](https://user-images.githubusercontent.com/5139098/99662114-1bb76780-2a65-11eb-8ac9-b905ab7f4539.png)

If we connect them using job `2` as the dependency, the resulting workflow would look like this.

![3](https://user-images.githubusercontent.com/5139098/99662230-443f6180-2a65-11eb-96df-adf484560922.png)

## Todo

This is still a work in progress.

- [ ] Add ability to have a workflow as a _dependency_, i.e. `->addJob(new Job(), [OtherWorkflow::class])`
- [ ] It should be possible to depend both on a workflow and on a step (or steps) of the parent workflow
- [ ] You should be able to freely combine all of these things (e.g. adding a workflow with a dependency on another workflow)