### PR TITLE
fix: return the started workflow

### DIFF
--- a/src/AbstractWorkflow.php
+++ b/src/AbstractWorkflow.php
@@ -7,9 +7,9 @@ use Sassnowski\Venture\Models\Workflow;
 
 abstract class AbstractWorkflow
 {
-    public static function start(): void
+    public static function start(): Workflow
     {
-        (new static(...func_get_args()))->run();
+        return (new static(...func_get_args()))->run();
     }
 
     private function run(): Workflow


### PR DESCRIPTION
According to the documentation you should be able to use the newly started workflow using
```php
$workflow = PublishPodcastWorkflow::start($podcast);
```

Which is not the case, as `start` doesn't return anything.

This PR aligns the code with the documentation.