### PR TITLE
Duplicate jobs support

### DIFF
--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -130,9 +130,12 @@ class DependencyGraph
     private function resolveStepId($job): ?string
     {
         // dependency can be a class object, class name or stepId
-        $className = is_object($job) ? get_class($job) : $job;
-        if (array_key_exists($className, $this->classMap)) {
-            return Arr::last($this->classMap[$className] ?? []);
+        if (is_object($job)) {
+            return $job->stepId;
+        }
+
+        if (array_key_exists($job, $this->classMap)) {
+            return Arr::last($this->classMap[$job] ?? []);
         }
 
         // we're dealing with a stepId

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -4,6 +4,7 @@ namespace Sassnowski\Venture;
 
 use Closure;
 use DateInterval;
+use Illuminate\Support\Arr;
 use function count;
 use DateTimeInterface;
 use function array_diff;
@@ -204,6 +205,18 @@ class WorkflowDefinition
         }
 
         return count(array_diff($resolvedDependencies, $workflowDependencies['dependencies'])) === 0;
+    }
+
+    public function getWorkflow($workflow): ?AbstractWorkflow
+    {
+        $className = is_object($workflow) ? get_class($workflow) : $workflow;
+        $workflows = collect($this->workflows[$className] ?? []);
+
+        if (is_string($workflow)) {
+            return $workflows->last()['instance'] ?? null;
+        }
+
+        return $workflows->firstWhere('instance', '===', $workflow)['instance'] ?? null;
     }
 
     private function getJobByClassName(string $className): ?array

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -25,3 +25,12 @@ function createWorkflowJob(Workflow $workflow, array $attributes = []): Workflow
         'finished_at' => null,
     ], $attributes));
 }
+
+function getPropertyValue($object, $property)
+{
+    $reflection = new \ReflectionClass($object);
+    $property = $reflection->getProperty($property);
+    $property->setAccessible(true);
+
+    return $property->getValue($object);
+}

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Carbon\Carbon;
+use Stubs\TestAbstractWorkflow;
 use Stubs\TestJob1;
 use Stubs\TestJob2;
 use Stubs\TestJob3;
@@ -489,6 +490,32 @@ it('returns true if workflow contains workflow with the correct dependency insta
 
     assertTrue($definition->hasWorkflow($workflow, [$job1]));
     assertTrue($definition->hasWorkflow($workflow2, [$job2]));
+});
+
+it('returns the added workflow by instance', function () {
+    $workflow = new TestAbstractWorkflow();
+    $definition = (new WorkflowDefinition())
+        ->addWorkflow($workflow, []);
+
+    assertEquals($workflow, $definition->getWorkflow($workflow));
+});
+
+it('returns the added workflow by class', function () {
+    $workflow = new TestAbstractWorkflow();
+    $definition = (new WorkflowDefinition())
+        ->addWorkflow($workflow, []);
+
+    assertEquals($workflow, $definition->getWorkflow(TestAbstractWorkflow::class));
+});
+
+it('returns the last added workflow when getting workflow by class', function () {
+    $workflow1 = new TestAbstractWorkflow();
+    $workflow2 = new TestAbstractWorkflow();
+    $definition = (new WorkflowDefinition())
+        ->addWorkflow($workflow1, [])
+        ->addWorkflow($workflow2, []);
+
+    assertEquals($workflow2, $definition->getWorkflow(TestAbstractWorkflow::class));
 });
 
 it('throws an exception when trying to add a job without the ShouldQueue interface', function () {

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -376,53 +376,26 @@ it('can add another workflow', function () {
 });
 
 it('returns true if workflow contains workflow instance with the correct dependencies', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
+    $workflow = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob(new TestJob1())
-        ->addJob(new TestJob2())
-        ->addJob(new TestJob3(), [TestJob1::class])
         ->addWorkflow($workflow, [TestJob1::class]);
 
     assertTrue($definition->hasWorkflow($workflow, [TestJob1::class]));
 });
 
 it('returns false if workflow contains workflow instance, but with incorrect dependencies', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
+    $workflow = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob(new TestJob1())
         ->addJob(new TestJob2())
-        ->addJob(new TestJob3(), [TestJob1::class])
         ->addWorkflow($workflow, [TestJob1::class]);
 
     assertFalse($definition->hasWorkflow($workflow, [TestJob2::class]));
 });
 
 it('returns true if workflow contains workflow instance with the correct dependency instances', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
+    $workflow = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob($job1 = new TestJob1())
         ->addJob(new TestJob2())
@@ -433,15 +406,7 @@ it('returns true if workflow contains workflow instance with the correct depende
 });
 
 it('returns true if workflow contains workflow class with the correct dependency instances', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
+    $workflow = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob($job1 = new TestJob1())
         ->addJob(new TestJob2())
@@ -452,15 +417,7 @@ it('returns true if workflow contains workflow class with the correct dependency
 });
 
 it('returns false if workflow contains workflow instance, but with incorrect dependency instances', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
+    $workflow = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob($job1 = new TestJob1())
         ->addJob($job2 = new TestJob1())
@@ -471,16 +428,8 @@ it('returns false if workflow contains workflow instance, but with incorrect dep
 });
 
 it('returns true if workflow contains workflow with the correct dependency instances when adding workflow multiple times', function () {
-    $workflow = new class extends AbstractWorkflow {
-        public function definition(): WorkflowDefinition
-        {
-            return WorkflowFacade::define('::name::')
-                ->addJob(new TestJob4())
-                ->addJob(new TestJob5())
-                ->addJob(new TestJob6(), [TestJob4::class]);
-        }
-    };
-    $workflow2 = clone $workflow;
+    $workflow = new TestAbstractWorkflow();
+    $workflow2 = new TestAbstractWorkflow();
     $definition = (new WorkflowDefinition())
         ->addJob($job1 = new TestJob1())
         ->addJob($job2 = new TestJob2())


### PR DESCRIPTION
I took the liberty of trying to solve the limitation of duplicate jobs, as I need it for a project.

I'm guessing there's a few areas in the code you might want to have changed or adjusted, so consider this more of a jumping off point for discussion :)

This PR changes the following;
- Instead of relying on `jobClassName`, switch to using `stepId` in the graph
- Keep a `classMap` for lookup, instead of having to inspect the graph constantly
- Add `getDependenciesAsJobs` for similar functionality to `getDependantJobs` but backwards compatible by keeping current method
- Loosen visibility of `resolveDependencies` so `WorkflowDefinition` can use it
- Added `hasWorkflow` method to easier test if workflows were merged instead of having to assert all of the individual jobs were added
- Added `getWorkflow` method to easier make assertions on added workflows