### PR TITLE
Return workflow model from workflow start method

### DIFF
--- a/src/AbstractWorkflow.php
+++ b/src/AbstractWorkflow.php
@@ -7,9 +7,9 @@ use Sassnowski\Venture\Models\Workflow;
 
 abstract class AbstractWorkflow
 {
-    public static function start(): void
+    public static function start(): Workflow
     {
-        (new static(...func_get_args()))->run();
+        return (new static(...func_get_args()))->run();
     }
 
     private function run(): Workflow

--- a/tests/AbstractWorkflowTest.php
+++ b/tests/AbstractWorkflowTest.php
@@ -1,17 +1,20 @@
 <?php declare(strict_types=1);
 
+use Sassnowski\Venture\Models\Workflow as WorkflowModel;
 use Stubs\TestAbstractWorkflow;
 use Stubs\WorkflowWithParameter;
 use Sassnowski\Venture\Facades\Workflow;
+use function PHPUnit\Framework\assertInstanceOf;
 
 uses(TestCase::class);
 
 it('can be started', function () {
     Workflow::fake();
 
-    TestAbstractWorkflow::start();
+    $workflow = TestAbstractWorkflow::start();
 
     Workflow::assertStarted(TestAbstractWorkflow::class);
+    assertInstanceOf(WorkflowModel::class, $workflow);
 });
 
 it('passes the parameters to the constructor of the workflow', function () {

--- a/tests/AbstractWorkflowTest.php
+++ b/tests/AbstractWorkflowTest.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
-use Sassnowski\Venture\Models\Workflow as WorkflowModel;
 use Stubs\TestAbstractWorkflow;
 use Stubs\WorkflowWithParameter;
 use Sassnowski\Venture\Facades\Workflow;
+use Sassnowski\Venture\Models\Workflow as WorkflowModel;
 use function PHPUnit\Framework\assertInstanceOf;
 
 uses(TestCase::class);
@@ -13,8 +13,8 @@ it('can be started', function () {
 
     $workflow = TestAbstractWorkflow::start();
 
-    Workflow::assertStarted(TestAbstractWorkflow::class);
     assertInstanceOf(WorkflowModel::class, $workflow);
+    Workflow::assertStarted(TestAbstractWorkflow::class);
 });
 
 it('passes the parameters to the constructor of the workflow', function () {


### PR DESCRIPTION
In the documentation it says: (https://laravel-venture.netlify.app/usage/keeping-track-of-workflows.html#persistance)
> When you start a workflow, an instance of the workflow will be returned.

However I couldn't find this in the code, so I've added it there.