### PR TITLE
fix: use lockForUpdate to prevent concurrency bugs

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -89,7 +89,13 @@ class Workflow extends Model
     public function onStepFailed($job, Throwable $e): void
     {
         DB::transaction(function () use ($job, $e) {
-            $this->jobs_failed++;
+            /** @var self $workflow */
+            $workflow = $this->newQuery()
+                ->whereKey($this->getKey())
+                ->lockForUpdate()
+                ->firstOrFail(['jobs_failed']);
+
+            $this->jobs_failed = $workflow->jobs_failed + 1;
             $this->save();
 
             optional($job->step())->update([
@@ -163,8 +169,14 @@ class Workflow extends Model
     private function markJobAsFinished($job): void
     {
         DB::transaction(function () use ($job) {
-            $this->finished_jobs = array_merge($this->finished_jobs, [$job->jobId ?: get_class($job)]);
-            $this->jobs_processed++;
+            /** @var self $workflow */
+            $workflow = $this->newQuery()
+                ->whereKey($this->getKey())
+                ->lockForUpdate()
+                ->firstOrFail(['finished_jobs', 'jobs_processed']);
+
+            $this->finished_jobs = array_merge($workflow->finished_jobs, [$job->jobId ?: get_class($job)]);
+            $this->jobs_processed = $workflow->jobs_processed + 1;
             $this->save();
 
             optional($job->step())->update(['finished_at' => now()]);

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -91,9 +91,8 @@ class Workflow extends Model
         DB::transaction(function () use ($job, $e) {
             /** @var self $workflow */
             $workflow = $this->newQuery()
-                ->whereKey($this->getKey())
                 ->lockForUpdate()
-                ->firstOrFail(['jobs_failed']);
+                ->findOrFail($this->getKey(), ['jobs_failed']);
 
             $this->jobs_failed = $workflow->jobs_failed + 1;
             $this->save();
@@ -171,9 +170,8 @@ class Workflow extends Model
         DB::transaction(function () use ($job) {
             /** @var self $workflow */
             $workflow = $this->newQuery()
-                ->whereKey($this->getKey())
                 ->lockForUpdate()
-                ->firstOrFail(['finished_jobs', 'jobs_processed']);
+                ->findOrFail($this->getKey(), ['finished_jobs', 'jobs_processed']);
 
             $this->finished_jobs = array_merge($workflow->finished_jobs, [$job->jobId ?: get_class($job)]);
             $this->jobs_processed = $workflow->jobs_processed + 1;


### PR DESCRIPTION
I'm not entirely sure how to prove the issue with a test (or that the fix works), but using Horizon with multiple workers, I've seen a fair bit of workflows getting 'stuck' and never marked as finished, even though all jobs gets marked as finished.
Debugging a bit, I found the cause to be the transaction in `markJobAsFinished`.

In one instance, I had two horizon workers logging a statement inside the transaction with ~30ms apart, both trying to increment the `jobs_processed` by one, but trying to add their own job id to the `finished_jobs`.

After this patch, I'm no longer seeing Workflows with 'out of sync' `jobs_processed` count.