### PR TITLE
feat: save dependantJobs as array of stepIds rather than job instances

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -79,7 +79,7 @@ class Workflow extends Model
             return;
         }
 
-        $jobs = WorkflowJob::where('uuid', $job->dependantJobs)
+        WorkflowJob::whereIn('uuid', $job->dependantJobs)
             ->get('job')
             ->pluck('job')
             ->map(fn ($job) => unserialize($job))

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -59,7 +59,9 @@ class WorkflowDefinition
         }
 
         $this->jobs[$id] = [
-            'job' => $job,
+            'job' => $job
+                ->withJobId($id)
+                ->withStepId(Str::orderedUuid()),
             'name' => $name ?: get_class($job),
         ];
 
@@ -121,8 +123,6 @@ class WorkflowDefinition
         foreach ($this->jobs as $id => $job) {
             $job['job']
                 ->withWorkflowId($workflow->id)
-                ->withStepId(Str::orderedUuid())
-                ->withJobId($id)
                 ->withDependantJobs($this->graph->getDependantJobs($id))
                 ->withDependencies($this->graph->getDependencies($id));
         }

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -82,6 +82,7 @@ class WorkflowDefinition
         $this->graph->connectGraph($definition->graph, $workflowId, $dependencies);
 
         foreach ($definition->jobs as $jobId => $job) {
+            $job['job'] = $job['job']->withJobId($workflowId . '.' . $jobId);
             $this->jobs[$workflowId . '.' . $jobId] = $job;
         }
 

--- a/src/WorkflowStep.php
+++ b/src/WorkflowStep.php
@@ -2,6 +2,7 @@
 
 namespace Sassnowski\Venture;
 
+use Illuminate\Support\Arr;
 use Ramsey\Uuid\UuidInterface;
 use Sassnowski\Venture\Models\Workflow;
 use Sassnowski\Venture\Models\WorkflowJob;
@@ -32,7 +33,7 @@ trait WorkflowStep
 
     public function withDependantJobs(array $jobs): self
     {
-        $this->dependantJobs = $jobs;
+        $this->dependantJobs = Arr::pluck($jobs, 'stepId');
 
         return $this;
     }

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -25,3 +25,10 @@ function createWorkflowJob(Workflow $workflow, array $attributes = []): Workflow
         'finished_at' => null,
     ], $attributes));
 }
+
+function wrapJobsForWorkflow($jobs) {
+    return collect($jobs)->map(fn ($job) => [
+        'job' => $job->withJobId($job->jobId ?? get_class($job)),
+        'name' => get_class($job)
+    ])->all();
+}

--- a/tests/Stubs/NestedWorkflow.php
+++ b/tests/Stubs/NestedWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Stubs;
+
+use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\Facades\Workflow as WorkflowFacade;
+use Sassnowski\Venture\WorkflowDefinition;
+
+class NestedWorkflow extends AbstractWorkflow
+{
+    public function __construct(public $job = null)
+    {
+        $this->job ??= new TestJob1();
+    }
+
+    public function definition(): WorkflowDefinition
+    {
+        return WorkflowFacade::define('::name::')->addJob($this->job);
+    }
+}
+

--- a/tests/Stubs/WorkflowWithWorkflow.php
+++ b/tests/Stubs/WorkflowWithWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Stubs;
+
+use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\Facades\Workflow as WorkflowFacade;
+use Sassnowski\Venture\WorkflowDefinition;
+
+class WorkflowWithWorkflow extends AbstractWorkflow
+{
+    public function __construct(public $workflow)
+    {
+    }
+
+    public function definition(): WorkflowDefinition
+    {
+        return WorkflowFacade::define('::name::')
+            ->addWorkflow($this->workflow);
+    }
+}
+

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -121,7 +121,7 @@ it('sets the dependants of a job', function () {
         ->addJob($testJob2, dependencies: [TestJob1::class])
         ->build();
 
-    assertEquals([$testJob2], $testJob1->dependantJobs);
+    assertEquals([$testJob2->stepId], $testJob1->dependantJobs);
     assertEquals([], $testJob2->dependantJobs);
 });
 

--- a/tests/WorkflowDefinitionTest.php
+++ b/tests/WorkflowDefinitionTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Carbon\Carbon;
+use Stubs\NestedWorkflow;
 use Stubs\TestJob1;
 use Stubs\TestJob2;
 use Stubs\TestJob3;
@@ -369,6 +370,15 @@ it('adding another workflow namespaces the nested workflow\'s job ids', function
     assertTrue($definition->hasJobWithDependencies(TestJob2::class, [TestJob1::class]));
 });
 
+it('adding another workflow updates the job id on nested job instances', function () {
+    $definition = (new WorkflowDefinition())
+        ->addJob(new TestJob1())
+        ->addJob(new TestJob2(), [TestJob1::class])
+        ->addWorkflow(new NestedWorkflow($job = new TestJob1()));
+
+    assertEquals(NestedWorkflow::class . '.' . TestJob1::class, $job->jobId);
+});
+
 it('throws an exception when trying to add a job without the ShouldQueue interface', function () {
     (new WorkflowDefinition())->addJob(new NonQueueableJob());
 })->expectException(NonQueueableWorkflowStepException::class);
@@ -418,10 +428,3 @@ class DummyCallback
     }
 }
 
-class NestedWorkflow extends AbstractWorkflow
-{
-    public function definition(): WorkflowDefinition
-    {
-        return WorkflowFacade::define('::name::')->addJob(new TestJob1());
-    }
-}


### PR DESCRIPTION
I recently started having concerns about the payload size when saving `dependantJobs` with full job payloads and today I got my first exception for `workflow_jobs.job` column being too small.
Average size of the `job` column for my project while testing is almost 20kb, with jobs regularly creeping up towards 40-50kb   and this is just for the small workflows/jobs in the project.
This PR reduces the size of the `job` column by 85% on average for me, but upwards of 95% on my current test data.

What are your thoughts on this?