### PR TITLE
Support User Task for manual job completion

### DIFF
--- a/src/Facades/Workflow.php
+++ b/src/Facades/Workflow.php
@@ -12,6 +12,7 @@ use Sassnowski\Venture\Manager\WorkflowManagerFake;
  * @method static bool hasStarted(string $workflowClass, ?callable $callback = null)
  * @method static void assertStarted(string $workflowDefinition, ?callable $callback = null)
  * @method static void assertNotStarted(string $workflowDefinition, ?callable $callback = null)
+ * @method static void completeJob(int $jobId)
  *
  * @see \Sassnowski\Venture\Manager\WorkflowManager
  */

--- a/src/Manager/WorkflowManager.php
+++ b/src/Manager/WorkflowManager.php
@@ -38,8 +38,10 @@ class WorkflowManager implements WorkflowManagerInterface
         return $workflow;
     }
 
-    public function job(int $workflowId): ?WorkflowJob
+    public function completeJob(int $jobId): void
     {
-        return Workflow::find($workflowId);
+        $jobInstance = WorkflowJob::with('workflow')->find($jobId);
+
+        optional($jobInstance->workflow())->onStepFinished($jobInstance);
     }
 }

--- a/src/Manager/WorkflowManager.php
+++ b/src/Manager/WorkflowManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Sassnowski\Venture\Models\Workflow;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\Models\WorkflowJob;
 use Sassnowski\Venture\WorkflowDefinition;
 
 class WorkflowManager implements WorkflowManagerInterface
@@ -35,5 +36,10 @@ class WorkflowManager implements WorkflowManagerInterface
         });
 
         return $workflow;
+    }
+
+    public function job(int $workflowId): ?WorkflowJob
+    {
+        return Workflow::find($workflowId);
     }
 }

--- a/src/Manager/WorkflowManagerFake.php
+++ b/src/Manager/WorkflowManagerFake.php
@@ -6,6 +6,7 @@ use Closure;
 use Sassnowski\Venture\Models\Workflow;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\Models\WorkflowJob;
 use Sassnowski\Venture\WorkflowDefinition;
 
 class WorkflowManagerFake implements WorkflowManagerInterface
@@ -35,6 +36,11 @@ class WorkflowManagerFake implements WorkflowManagerInterface
         $this->started[get_class($abstractWorkflow)] = $abstractWorkflow;
 
         return $workflow;
+    }
+
+    public function job(int $workflowId): ?WorkflowJob
+    {
+        return Workflow::find($workflowId);
     }
 
     public function hasStarted(string $workflowClass, ?callable $callback = null): bool

--- a/src/Manager/WorkflowManagerFake.php
+++ b/src/Manager/WorkflowManagerFake.php
@@ -38,9 +38,9 @@ class WorkflowManagerFake implements WorkflowManagerInterface
         return $workflow;
     }
 
-    public function job(int $workflowId): ?WorkflowJob
+    public function completeJob(int $jobId): void
     {
-        return Workflow::find($workflowId);
+        // todo
     }
 
     public function hasStarted(string $workflowClass, ?callable $callback = null): bool

--- a/src/Manager/WorkflowManagerInterface.php
+++ b/src/Manager/WorkflowManagerInterface.php
@@ -4,6 +4,7 @@ namespace Sassnowski\Venture\Manager;
 
 use Sassnowski\Venture\Models\Workflow;
 use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\Models\WorkflowJob;
 use Sassnowski\Venture\WorkflowDefinition;
 
 interface WorkflowManagerInterface
@@ -11,4 +12,6 @@ interface WorkflowManagerInterface
     public function define(string $workflowName): WorkflowDefinition;
 
     public function startWorkflow(AbstractWorkflow $abstractWorkflow): Workflow;
+
+    public function job(int $workflowId): ?WorkflowJob;
 }

--- a/src/Manager/WorkflowManagerInterface.php
+++ b/src/Manager/WorkflowManagerInterface.php
@@ -4,7 +4,6 @@ namespace Sassnowski\Venture\Manager;
 
 use Sassnowski\Venture\Models\Workflow;
 use Sassnowski\Venture\AbstractWorkflow;
-use Sassnowski\Venture\Models\WorkflowJob;
 use Sassnowski\Venture\WorkflowDefinition;
 
 interface WorkflowManagerInterface
@@ -13,5 +12,5 @@ interface WorkflowManagerInterface
 
     public function startWorkflow(AbstractWorkflow $abstractWorkflow): Workflow;
 
-    public function job(int $workflowId): ?WorkflowJob;
+    public function completeJob(int $jobId): void;
 }

--- a/src/WorkflowEventSubscriber.php
+++ b/src/WorkflowEventSubscriber.php
@@ -37,6 +37,9 @@ class WorkflowEventSubscriber
         $jobInstance = $this->getJobInstance($event->job);
 
         if ($this->isWorkflowStep($jobInstance)) {
+            if ($this->isUserTask($jobInstance)) {
+                return;
+            }
             optional($jobInstance->workflow())->onStepFinished($jobInstance);
         }
     }
@@ -72,6 +75,15 @@ class WorkflowEventSubscriber
         $uses = class_uses_recursive($job);
 
         return in_array(WorkflowStep::class, $uses);
+    }
+
+    private function isUserTask($job): bool
+    {
+        if (! $this->isWorkflowStep($job)) {
+            return false;
+        }
+
+        return $job->isUserTask();
     }
 
     private function getJobInstance(Job $job)

--- a/src/WorkflowStep.php
+++ b/src/WorkflowStep.php
@@ -13,6 +13,7 @@ trait WorkflowStep
     public ?int $workflowId = null;
     public ?string $stepId = null;
     public ?string $jobId = null;
+    public bool $isUserTask = false;
 
     public function withWorkflowId(int $workflowId): self
     {
@@ -65,5 +66,17 @@ trait WorkflowStep
         }
 
         return WorkflowJob::where('uuid', $this->stepId)->first();
+    }
+
+    public function withUserTask(): self
+    {
+        $this->isUserTask = true;
+
+        return $this;
+    }
+
+    public function isUserTask(): bool
+    {
+        return $this->isUserTask;
     }
 }

--- a/tests/Stubs/TestUserTask1.php
+++ b/tests/Stubs/TestUserTask1.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Stubs;
+
+use Illuminate\Bus\Queueable;
+use Sassnowski\Venture\WorkflowStep;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Sassnowski\Venture\WorkflowUserTask;
+
+class TestUserTask1 implements ShouldQueue
+{
+    use Queueable, WorkflowStep;
+
+    public function isUserTask(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
First try on #32 . Go ahead and change what you need to make it fit.

A couple of things I considered. I went away from the trait `WorkflowUserTask`, as it does not implement anything. Its only needed for identification. 

### How to mark a job as UserTask

```php
class MyJob implements ShouldQueue
{
    use WorkflowStep;
    
    public function isUserTask(): bool
    {
        return true;
    }
}
```

### How to manually complete the job:

```php
Workflow::completeJob($jobId);
```


One thing that could be improved is the tests of `completeJob` as the facade fake is not done. Not sure how you want it. 
