### PR TITLE
Add missing `jobs_failed` integer model cast

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -33,6 +33,7 @@ class Workflow extends Model
     protected $casts = [
         'finished_jobs' => 'json',
         'job_count' => 'int',
+        'jobs_failed' => 'int',
         'jobs_processed' => 'int',
     ];
 


### PR DESCRIPTION
## Description

A cast is missing for the `jobs_failed` count.

## Details

When returning workflows via a JSON response and running tests using Laravel's [assertable JSON feature](https://laravel.com/docs/8.x/http-tests#asserting-json-types), I have to use a string instead of an integer (since it performs strict type checks):

```php
$json->has('data.0', function ($data) {
    // ...
    $data->where('job_count', 0);
    $data->where('jobs_processed', 0);
    $data->where('jobs_failed', '0');
});
```

Let me know if you'd like any tests added. I've assumed since it's a small omission, that none would be needed.

Thanks for your time! ❤️ 