### PR TITLE
Add `isDone()` method for easily retrieving workflow "done" status

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -116,6 +116,11 @@ class Workflow extends Model
         return $this->cancelled_at !== null;
     }
 
+    public function isDone(): bool
+    {
+        return ($this->jobs_processed + $this->jobs_failed) === $this->job_count;
+    }
+
     public function cancel(): void
     {
         if ($this->isCancelled()) {

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -116,7 +116,7 @@ class Workflow extends Model
         return $this->cancelled_at !== null;
     }
 
-    public function isDone(): bool
+    public function hasRan(): bool
     {
         return ($this->jobs_processed + $this->jobs_failed) === $this->job_count;
     }

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -254,6 +254,30 @@ it('does not break a leg if no catch callback is configured', function () {
     assertEquals(0, $_SERVER['__catch.count']);
 });
 
+it('is done by default', function () {
+    assertTrue(createWorkflow()->isDone());
+});
+
+it('is done when job count equals total processed and failed', function () {
+    $workflow = createWorkflow([
+        'job_count' => 4,
+        'jobs_processed' => 3,
+        'jobs_failed' => 1,
+    ]);
+
+    assertTrue($workflow->isDone());
+});
+
+it('is not done when job count does not equal total processed and failed', function () {
+    $workflow = createWorkflow([
+        'job_count' => 4,
+        'jobs_processed' => 2,
+        'jobs_failed' => 1,
+    ]);
+
+    assertFalse($workflow->isDone());
+});
+
 it('is not cancelled by default', function () {
     assertFalse(createWorkflow()->isCancelled());
 });

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -254,28 +254,28 @@ it('does not break a leg if no catch callback is configured', function () {
     assertEquals(0, $_SERVER['__catch.count']);
 });
 
-it('is done by default', function () {
-    assertTrue(createWorkflow()->isDone());
+it('has ran by default', function () {
+    assertTrue(createWorkflow()->hasRan());
 });
 
-it('is done when job count equals total processed and failed', function () {
+it('has ran when job count equals total processed and failed', function () {
     $workflow = createWorkflow([
         'job_count' => 4,
         'jobs_processed' => 3,
         'jobs_failed' => 1,
     ]);
 
-    assertTrue($workflow->isDone());
+    assertTrue($workflow->hasRan());
 });
 
-it('is not done when job count does not equal total processed and failed', function () {
+it('has not ran when job count does not equal total processed and failed', function () {
     $workflow = createWorkflow([
         'job_count' => 4,
         'jobs_processed' => 2,
         'jobs_failed' => 1,
     ]);
 
-    assertFalse($workflow->isDone());
+    assertFalse($workflow->hasRan());
 });
 
 it('is not cancelled by default', function () {

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -254,8 +254,8 @@ it('does not break a leg if no catch callback is configured', function () {
     assertEquals(0, $_SERVER['__catch.count']);
 });
 
-it('has ran by default', function () {
-    assertTrue(createWorkflow()->hasRan());
+it('has not run by default', function () {
+    assertFalse(createWorkflow(['job_count' => 1])->hasRan());
 });
 
 it('has ran when job count equals total processed and failed', function () {


### PR DESCRIPTION
## Description

This PR adds the ability to easily fetch the entire completion status of a workflow. One that may have processed and failed jobs, but is actually done processing.

## Purpose

In a workflow, some jobs may pass and some may fail, leaving the `finished_at` and `cancelled_at` timestamps empty. This simple helper method allows me to check if the workflow is actually "done", and then perform further analysis afterwards.

Let me know if you'd like more tests added. Thanks so much for this package and your time! ❤️ 