### PR TITLE
Add interface to abstract id generation for workflow steps

### DIFF
--- a/config/venture.php
+++ b/config/venture.php
@@ -1,6 +1,18 @@
 <?php declare(strict_types=1);
 
+use Sassnowski\Venture\ClassNameStepIdGenerator;
+
 return [
     'workflow_table' => 'workflows',
+
     'jobs_table' => 'workflow_jobs',
+
+    /*
+     * The class that should be used to generate an id for a
+     * workflow job if no explicit id was provided. In most cases,
+     * you won't have to change this.
+     *
+     * This class needs to implement the `Sassnowski\Venture\StepIdGenerator` interface.
+     */
+    'workflow_step_id_generator_class' => ClassNameStepIdGenerator::class,
 ];

--- a/src/ClassNameStepIdGenerator.php
+++ b/src/ClassNameStepIdGenerator.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Sassnowski\Venture;
+
+final class ClassNameStepIdGenerator implements StepIdGenerator
+{
+    public function generateId(object $job): string
+    {
+        return get_class($job);
+    }
+}

--- a/src/Manager/WorkflowManager.php
+++ b/src/Manager/WorkflowManager.php
@@ -6,20 +6,20 @@ use Closure;
 use Sassnowski\Venture\Models\Workflow;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\StepIdGenerator;
 use Sassnowski\Venture\WorkflowDefinition;
 
 class WorkflowManager implements WorkflowManagerInterface
 {
-    private Dispatcher $dispatcher;
-
-    public function __construct(Dispatcher $dispatcher)
-    {
-        $this->dispatcher = $dispatcher;
+    public function __construct(
+        private Dispatcher $dispatcher,
+        private StepIdGenerator $stepIdGenerator,
+    ) {
     }
 
     public function define(string $workflowName): WorkflowDefinition
     {
-        return new WorkflowDefinition($workflowName);
+        return new WorkflowDefinition($workflowName, $this->stepIdGenerator);
     }
 
     public function startWorkflow(AbstractWorkflow $abstractWorkflow): Workflow

--- a/src/StepIdGenerator.php
+++ b/src/StepIdGenerator.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Sassnowski\Venture;
+
+interface StepIdGenerator
+{
+    public function generateId(object $job): string;
+}

--- a/src/VentureServiceProvider.php
+++ b/src/VentureServiceProvider.php
@@ -3,7 +3,9 @@
 namespace Sassnowski\Venture;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Sassnowski\Venture\Manager\WorkflowManager;
+use Illuminate\Contracts\Foundation\Application;
 
 class VentureServiceProvider extends ServiceProvider
 {
@@ -26,8 +28,15 @@ class VentureServiceProvider extends ServiceProvider
             __DIR__ . '/../config/venture.php',
             'venture'
         );
+
         /** @psalm-suppress UndefinedInterfaceMethod */
         $this->app['events']->subscribe(WorkflowEventSubscriber::class);
-        $this->app->bind('venture.manager', WorkflowManager::class);
+
+        $this->app->bind('venture.manager', function (Application $app) {
+            return new WorkflowManager(
+                $app->get(Dispatcher::class),
+                $app->get(config('venture.workflow_step_id_generator_class')),
+            );
+        });
     }
 }

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -24,9 +24,14 @@ class WorkflowDefinition
     protected ?string $catchCallback = null;
     protected array $nestedWorkflows = [];
 
-    public function __construct(protected string $workflowName = '')
-    {
+    private StepIdGenerator $stepIdGenerator;
+
+    public function __construct(
+        protected string $workflowName = '',
+        StepIdGenerator $stepIdGenerator = null,
+    ) {
         $this->graph = new DependencyGraph();
+        $this->stepIdGenerator = $stepIdGenerator ?: new ClassNameStepIdGenerator();
     }
 
     /**
@@ -53,7 +58,7 @@ class WorkflowDefinition
             throw NonQueueableWorkflowStepException::fromJob($job);
         }
 
-        $id = $this->buildIdentifier($id, $job);
+        $id ??= $this->stepIdGenerator->generateId($job);
 
         $this->graph->addDependantJob($job, $dependencies, $id);
 


### PR DESCRIPTION
This PR introduces a `StepIdGenerator` interface to abstract away how ids for workflow jobs are generated. 

## Rationale

The trigger for this change was to make integration between Venture and [Laravel Actions](https://laravelactions.com/) more seamless. Since Laravel Actions wraps jobs in a `JobDecorator` class, this would lead to an exception when trying to add multiple of these jobs to a workflow without providing explicit ids for them. This is described in more detail [here](https://github.com/lorisleiva/laravel-actions/issues/145).

With this change, it's not trivial to provide a different implementation of the interface that takes this case into account.

```php
use Lorisleiva\Actions\Decorators\JobDecorator;

final class LaravelActionsStepIdGenerator implements StepIdGenerator
{
    public function generateId(object $step): string
    {
        if ($step instanceof JobDecorator) {
            $step = $step->getAction();
        }

        return get_class($step);
    }
}
```

The default implementation simply uses `get_class` on the job instance. So from the outside, the behavior when not passing an explicit id remains unchanged.