### PR TITLE
Fix bug with missing workflow step generator in config if already published

### DIFF
--- a/src/VentureServiceProvider.php
+++ b/src/VentureServiceProvider.php
@@ -5,6 +5,7 @@ namespace Sassnowski\Venture;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Sassnowski\Venture\Manager\WorkflowManager;
+use Sassnowski\Venture\ClassNameStepIdGenerator;
 use Illuminate\Contracts\Foundation\Application;
 
 class VentureServiceProvider extends ServiceProvider
@@ -33,9 +34,11 @@ class VentureServiceProvider extends ServiceProvider
         $this->app['events']->subscribe(WorkflowEventSubscriber::class);
 
         $this->app->bind('venture.manager', function (Application $app) {
+            $generator = config('venture.workflow_step_id_generator_class');
+
             return new WorkflowManager(
                 $app->get(Dispatcher::class),
-                $app->get(config('venture.workflow_step_id_generator_class')),
+                $app->get($generator ?? ClassNameStepIdGenerator::class),
             );
         });
     }

--- a/tests/BackwardsCompatabilityTest.php
+++ b/tests/BackwardsCompatabilityTest.php
@@ -27,7 +27,12 @@ it('can handle old workflows that still saved serialized dependent jobs instead 
 });
 
 it('can handle missing workflow step id generator class in config', function () {
-    config(['venture.workflow_step_id_generator_class' => null]);
+    config([
+        'venture' => [
+            'workflow_table' => 'workflows',
+            'jobs_table' => 'workflow_jobs',
+        ],
+    ]);
 
     expect(app('venture.manager'))->toBeInstanceOf(WorkflowManager::class);
 });

--- a/tests/BackwardsCompatabilityTest.php
+++ b/tests/BackwardsCompatabilityTest.php
@@ -4,6 +4,7 @@ use Stubs\TestJob1;
 use Stubs\TestJob2;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Bus;
+use Sassnowski\Venture\Manager\WorkflowManager;
 
 uses(TestCase::class);
 
@@ -23,4 +24,10 @@ it('can handle old workflows that still saved serialized dependent jobs instead 
     $workflow->onStepFinished($job1);
 
     Bus::assertDispatched(TestJob2::class);
+});
+
+it('can handle missing workflow step id generator class in config', function () {
+    config(['venture.workflow_step_id_generator_class' => null]);
+
+    expect(app('venture.manager'))->toBeInstanceOf(WorkflowManager::class);
 });


### PR DESCRIPTION
## Problem

Developers who have already published their `venture` config file, but do not have the new config option `workflow_step_id_generator_class` located inside will receive a Laravel container exception when attempting to resolve the `WorkflowManager`:

![Screen Shot 2021-11-18 at 1 24 38 PM](https://user-images.githubusercontent.com/6421846/142474632-79f4dabe-1d08-4c7b-8f7a-87e5ca187de9.png)

## Descritption

I encountered this bug as soon as I ran composer update in my repos and my GitHub actions executed.

Let me know if you require any more tests, thanks for your time! 😄 