### PR TITLE
Add ability to use a custom `Workflow` and `WorkflowJob` model

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sassnowski\Venture\Models;
 
 use Carbon\Carbon;
+use Sassnowski\Venture\Venture;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -22,7 +23,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Opis\Closure\SerializableClosure;
-use Sassnowski\Venture\Venture;
 use Throwable;
 
 /**

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -247,6 +247,7 @@ class Workflow extends Model
         if (\is_object($job->dependantJobs[0])) {
             $dependantJobs = collect($job->dependantJobs);
         } else {
+            /** @psalm-suppress PossiblyUndefinedMethod */
             $dependantJobs = app(Venture::$workflowJobModel)
                 ->whereIn('uuid', $job->dependantJobs)
                 ->get('job')

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Opis\Closure\SerializableClosure;
+use Sassnowski\Venture\Venture;
 use Throwable;
 
 /**
@@ -63,7 +64,7 @@ class Workflow extends Model
 
     public function jobs(): HasMany
     {
-        return $this->hasMany(WorkflowJob::class);
+        return $this->hasMany(Venture::$workflowJobModel);
     }
 
     public function addJobs(array $jobs): void
@@ -246,7 +247,8 @@ class Workflow extends Model
         if (\is_object($job->dependantJobs[0])) {
             $dependantJobs = collect($job->dependantJobs);
         } else {
-            $dependantJobs = WorkflowJob::whereIn('uuid', $job->dependantJobs)
+            $dependantJobs = app(Venture::$workflowJobModel)
+                ->whereIn('uuid', $job->dependantJobs)
                 ->get('job')
                 ->pluck('job')
                 ->map(fn (string $job) => \unserialize($job));

--- a/src/Models/WorkflowJob.php
+++ b/src/Models/WorkflowJob.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sassnowski\Venture\Models;
 
 use Carbon\Carbon;
+use Sassnowski\Venture\Venture;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Sassnowski\Venture\Venture;
 
 /**
  * @property string[] $edges

--- a/src/Models/WorkflowJob.php
+++ b/src/Models/WorkflowJob.php
@@ -16,6 +16,7 @@ namespace Sassnowski\Venture\Models;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Sassnowski\Venture\Venture;
 
 /**
  * @property string[] $edges
@@ -48,6 +49,6 @@ class WorkflowJob extends Model
 
     public function workflow(): BelongsTo
     {
-        return $this->belongsTo(Workflow::class);
+        return $this->belongsTo(Venture::$workflowModel);
     }
 }

--- a/src/Venture.php
+++ b/src/Venture.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sassnowski\Venture;
+
+use Sassnowski\Venture\Models\Workflow;
+use Sassnowski\Venture\Models\WorkflowJob;
+
+class Venture
+{
+    public static string $workflowModel = Workflow::class;
+
+    public static string $workflowJobModel = WorkflowJob::class;
+
+    public function useWorkflowModel(string $workflowModel): void
+    {
+        static::$workflowModel = $workflowModel;
+    }
+
+    public function useWorkflowJobModel(string $workflowJobModel): void
+    {
+        static::$workflowJobModel = $workflowJobModel;
+    }
+}

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -150,7 +150,7 @@ class WorkflowDefinition
 
     protected function makeWorkflow(array $attributes): Workflow
     {
-        return app(Workflow::class, compact('attributes'));
+        return app(Venture::$workflowModel, compact('attributes'));
     }
 
     public function name(): string

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -120,7 +120,7 @@ class WorkflowDefinition
 
     public function build(?Closure $beforeCreate = null): array
     {
-        $workflow = new Workflow([
+        $workflow = $this->makeWorkflow([
             'name' => $this->workflowName,
             'job_count' => \count($this->jobs),
             'jobs_processed' => 0,
@@ -146,6 +146,11 @@ class WorkflowDefinition
         $workflow->addJobs($this->jobs);
 
         return [$workflow, $this->graph->getJobsWithoutDependencies()];
+    }
+
+    protected function makeWorkflow(array $attributes): Workflow
+    {
+        return app(Workflow::class, compact('attributes'));
     }
 
     public function name(): string

--- a/src/WorkflowStep.php
+++ b/src/WorkflowStep.php
@@ -39,7 +39,7 @@ trait WorkflowStep
             return null;
         }
 
-        return Workflow::find($this->workflowId);
+        return app(Venture::$workflowModel)->find($this->workflowId);
     }
 
     public function withDependantJobs(array $jobs): self
@@ -76,6 +76,6 @@ trait WorkflowStep
             return null;
         }
 
-        return WorkflowJob::where('uuid', $this->stepId)->first();
+        return app(Venture::$workflowJobModel)->where('uuid', $this->stepId)->first();
     }
 }


### PR DESCRIPTION
Closes #43 

This PR adds the ability to override (by extending) the current workflow model via a new static class `Venture`:

```php
Venture::useWorkflowModel(MyWorkflow:class);
Venture::useWorkflowJobModel(MyWorkflowJob:class);
```

Laravel Cashier uses this same pattern for overriding its  `Customer`, `Subscription`, and `SubscriptionItem` models:

https://laravel.com/docs/9.x/billing#using-custom-models

```php
Cashier::useSubscriptionModel(Subscription::class);
```

https://github.com/laravel/cashier-stripe/blob/fb5d453e5cc2d9420d72e5c2508224ef9c1f0aad/src/Cashier.php#L204-L235

Let me know your thoughts! No hard feelings on closure ❤️ .

---

Note: I didn't add any tests since all the existing tests would fail if the implementation wasn't working. If you want some tests, let me know! 😄 