### PR TITLE
Add ability to chain workflows together

### DIFF
--- a/database/migrations/2022_04_07_174229_add_workflow_id_column_to_workflows_table.php
+++ b/database/migrations/2022_04_07_174229_add_workflow_id_column_to_workflows_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWorkflowIdColumnToWorkflowsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table(config('venture.workflow_table'), function (Blueprint $table) {
+            $table->unsignedBigInteger('workflow_id')->nullable();
+        });
+    }
+}

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -37,6 +37,7 @@ use Throwable;
  * @property int                $job_count
  * @property EloquentCollection $jobs
  * @property ?Workflow          $workflow
+ * @property EloquentCollection $workflows
  * @property int                $jobs_failed
  * @property int                $jobs_processed
  * @property string             $name

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -146,6 +146,7 @@ class Workflow extends Model
     {
         $children = $this->workflows()->get();
 
+        /** @psalm-suppress ArgumentTypeCoercion */
         $finished = $children->filter(fn (Workflow $workflow): bool => $workflow->isFinished());
 
         return $this->job_count === $this->jobs_processed && $finished->count() === $children->count();

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -146,7 +146,7 @@ class Workflow extends Model
     {
         $children = $this->workflows()->get();
 
-        $finished = $children->filter(fn (Workflow $workflow) => $workflow->isFinished());
+        $finished = $children->filter(fn (Workflow $workflow): bool => $workflow->isFinished());
 
         return $this->job_count === $this->jobs_processed && $finished->count() === $children->count();
     }

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -73,6 +73,39 @@ it('requires child workflows to be finished before reporting finished', function
     assertTrue($workflow1->isFinished());
 });
 
+it('does not report finished when deeply nested workflow is not finished', function (): void {
+    $workflow1 = createWorkflow([
+        'job_count' => 1,
+        'jobs_processed' => 1,
+    ]);
+
+    $workflow2 = createWorkflow([
+        'job_count' => 1,
+        'jobs_processed' => 1,
+    ]);
+
+    $workflow3 = createWorkflow([
+        'job_count' => 1,
+        'jobs_processed' => 0,
+    ]);
+
+    $workflow1->addWorkflow(
+        $workflow2->addWorkflow(
+            $workflow3
+        )
+    );
+
+    assertFalse($workflow1->isFinished());
+    assertFalse($workflow2->isFinished());
+    assertFalse($workflow3->isFinished());
+
+    $workflow3->update(['jobs_processed' => 1]);
+
+    assertTrue($workflow1->isFinished());
+    assertTrue($workflow2->isFinished());
+    assertTrue($workflow3->isFinished());
+});
+
 it('stores a finished job\'s id', function ($job, string $expectedJobId): void {
     $workflow = createWorkflow([
         'job_count' => 1,


### PR DESCRIPTION
Closes #45

## Description 

This PR adds the ability to chain workflows together via self-referencing relationships.

## Problem

Once a workflow has been started, we cannot modify its state by appending additional jobs or workflows.

What if we could instead simply chain workflows together, allowing us to have a parent workflow that only reports finished when all of its children have also finished?

This grants us the ability to start additional workflows inside of other workflow jobs, attaching them to the parent and allowing us to have a single workflow containing other workflows -- but operating independently.

For a parent workflow to report finished, its children (and its children) must also be finished.

## Example

Let's say we have a website where our users can upload an image of an animal and we must determine what _kind_ of animal it is and the _breed_.

To do this, we first need to send the image to find out what _kind_ of animal it is, then with that result, we need to execute additional jobs to find out the _breed_ of the animal.

Since we will have different _breed_ ML models depending on the _kind_ of animal, we cannot define an entire workflow, since we rely on the initial classification of the animal to dispatch the additional classification jobs.

```php
// app/Workflows/DetermineAnimal.php

public function __construct(protected $image) {}

public function definition(): AbstractWorkflow
{
    return Workflow::define('Determine Animal')
        ->addJob(new DetermineAnimalType($this->image));
}
```

```php
// app/Jobs/DetermineAnimalType.php

public function handle(Amazon $amazon)
{
    $result = $amazon->sendMLRequest('animal-ml-model', $this->image);

    $workflow = match ($result->kind) {
        'dog' => DetermineDogBreedWorkflow::start($this->image),
        'cat' => DetermineCatBreedWorkflow::start($this->image),
        default => throw new UnexpectedValueException('Unrecognized animal!'),
    };

    $this->image->update(['kind' => $result->kind]);

    $this->workflow()->addWorkflow($workflow);
}
```

```php
// app/Jobs/DetermineDogBreed.php

public function handle(Amazon $amazon)
{
    $result = $amazon->sendMLRequest('dog-breed-ml-model', $this->image);

    $this->image->update(['breed' => $result->breed]);
}
```

```php
if ($image->workflow()->isFinished()) {
    echo "The animal is a {$image->kind} and it is a {$image->breed}.";
}

// Displays: "The animal is a dog and it is a bulldog."
```

---

Let me know your thoughts on this implementation, and thanks again for this awesome library! ❤️ 