### PR TITLE
Add `markAsFinished()` method for overridability and make `markJobAsFinished()` protected

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -89,7 +89,7 @@ class Workflow extends Model
         }
 
         if ($this->isFinished()) {
-            $this->update(['finished_at' => Carbon::now()]);
+            $this->markAsFinished();
             $this->runThenCallback();
 
             return;
@@ -189,7 +189,12 @@ class Workflow extends Model
         ])->all();
     }
 
-    private function markJobAsFinished(object $job): void
+    protected function markAsFinished(): void
+    {
+        $this->update(['finished_at' => Carbon::now()]);
+    }
+
+    protected function markJobAsFinished(object $job): void
     {
         DB::transaction(function () use ($job): void {
             /** @var self $workflow */


### PR DESCRIPTION
This PR adds the ability for developers to override the `markAsFinished()` and `markJobAsFinished()` methods on their extended `Workflow` model to perform other logic after a workflow has been marked finished, or one of its jobs:

```php
Ventrue::useWorkflowModel(Workflow::class);
```

```php
class Worfklow extends VentureWorkflow
{
    protected function markAsFinished(): void
    {
        parent::markAsFinished();

        // Other logic...
    }

    protected function markJobAsFinished(object $job): void
    {
        parent::markJobAsFinished($job);

        // Other logic...
    }
}
```

Let me know your thoughts! Thanks for your time 🙏 

No hard feelings on closure ❤️ 