### PR TITLE
Fix `Venture` non static methods

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -64,7 +64,7 @@ class Workflow extends Model
 
     public function jobs(): HasMany
     {
-        return $this->hasMany(Venture::$workflowJobModel);
+        return $this->hasMany(Venture::$workflowJobModel, 'workflow_id');
     }
 
     public function addJobs(array $jobs): void

--- a/src/Models/WorkflowJob.php
+++ b/src/Models/WorkflowJob.php
@@ -49,6 +49,6 @@ class WorkflowJob extends Model
 
     public function workflow(): BelongsTo
     {
-        return $this->belongsTo(Venture::$workflowModel);
+        return $this->belongsTo(Venture::$workflowModel, 'workflow_id');
     }
 }

--- a/src/Venture.php
+++ b/src/Venture.php
@@ -21,12 +21,12 @@ class Venture
     public static string $workflowModel = Workflow::class;
     public static string $workflowJobModel = WorkflowJob::class;
 
-    public function useWorkflowModel(string $workflowModel): void
+    public static function useWorkflowModel(string $workflowModel): void
     {
         static::$workflowModel = $workflowModel;
     }
 
-    public function useWorkflowJobModel(string $workflowJobModel): void
+    public static function useWorkflowJobModel(string $workflowJobModel): void
     {
         static::$workflowJobModel = $workflowJobModel;
     }

--- a/tests/Stubs/CustomWorkflowJobModel.php
+++ b/tests/Stubs/CustomWorkflowJobModel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Sassnowski\Venture\Models\WorkflowJob;
+
+class CustomWorkflowJobModel extends WorkflowJob
+{
+}

--- a/tests/Stubs/CustomWorkflowModel.php
+++ b/tests/Stubs/CustomWorkflowModel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Sassnowski\Venture\Models\Workflow;
+
+class CustomWorkflowModel extends Workflow
+{
+}

--- a/tests/Stubs/TestJobWithHandle.php
+++ b/tests/Stubs/TestJobWithHandle.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Sassnowski\Venture\WorkflowStep;
+
+class TestJobWithHandle implements ShouldQueue
+{
+    use WorkflowStep;
+
+    public function handle()
+    {
+        return true;
+    }
+}

--- a/tests/Stubs/WorkflowWithJob.php
+++ b/tests/Stubs/WorkflowWithJob.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\WorkflowDefinition;
+
+class WorkflowWithJob extends AbstractWorkflow
+{
+    public function definition(): WorkflowDefinition
+    {
+        return (new WorkflowDefinition)->addJob(
+            new TestJobWithHandle
+        );
+    }
+}

--- a/tests/VentureTest.php
+++ b/tests/VentureTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+use Sassnowski\Venture\Models\Workflow;
+use Sassnowski\Venture\Models\WorkflowJob;
+use Sassnowski\Venture\Venture;
+use Stubs\CustomWorkflowJobModel;
+use Stubs\CustomWorkflowModel;
+use Stubs\WorkflowWithJob;
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertNotInstanceOf;
+
+uses(TestCase::class);
+
+afterEach(function () {
+    Venture::useWorkflowModel(Workflow::class);
+    Venture::useWorkflowJobModel(WorkflowJob::class);
+});
+
+it('can override workflow model', function () {
+    Venture::useWorkflowModel(CustomWorkflowModel::class);
+
+    assertInstanceOf(CustomWorkflowModel::class, WorkflowWithJob::start());
+});
+
+it('can override workflow job model', function () {
+    Venture::useWorkflowJobModel(CustomWorkflowJobModel::class);
+
+    assertInstanceOf(Workflow::class, $workflow = WorkflowWithJob::start());
+    assertCount(1, $jobs = $workflow->jobs()->get());
+    assertInstanceOf(CustomWorkflowJobModel::class, $job = $jobs->first());
+    assertInstanceOf(Workflow::class, $job->workflow);
+    assertNotInstanceOf(CustomWorkflowModel::class, $job->workflow);
+});
+
+it('can override workflow and job model', function () {
+    Venture::useWorkflowModel(CustomWorkflowModel::class);
+    Venture::useWorkflowJobModel(CustomWorkflowJobModel::class);
+    
+    assertInstanceOf(CustomWorkflowModel::class, $workflow = WorkflowWithJob::start());
+    assertCount(1, $jobs = $workflow->jobs()->get());
+    assertInstanceOf(CustomWorkflowJobModel::class, $job = $jobs->first());
+    assertInstanceOf(CustomWorkflowModel::class, $job->workflow);
+});


### PR DESCRIPTION
This fixes the non-static methods that I pushed in PR https://github.com/ksassnowski/venture/pull/44

I can't believe I didn't notice this 🙈  Sorry @ksassnowski!

I've added the tests that I should have added originally with the PR. 🙏 

I've also added `workflow_id` to the relationships so that the proper ID's are generated if a developer has a different workflow model class name (i.e. `CustomWorkflowModel`).