### PR TITLE
Add test for handling jobs with protected and private properties

### DIFF
--- a/tests/Stubs/TestJobWithHandle.php
+++ b/tests/Stubs/TestJobWithHandle.php
@@ -22,6 +22,5 @@ class TestJobWithHandle implements ShouldQueue
 
     public function handle()
     {
-        return true;
     }
 }

--- a/tests/Stubs/TestJobWithNonPublicProperties.php
+++ b/tests/Stubs/TestJobWithNonPublicProperties.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Sassnowski\Venture\WorkflowStep;
+
+class TestJobWithNonPublicProperties implements ShouldQueue
+{
+    use Queueable;
+    use WorkflowStep;
+
+    protected string $foo;
+    private string $bar;
+
+    public function __construct(string $foo, string $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function handle()
+    {
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function getBar(): string
+    {
+        return $this->bar;
+    }
+}

--- a/tests/Stubs/WorkflowWithDatabaseJob.php
+++ b/tests/Stubs/WorkflowWithDatabaseJob.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Stubs;
+
+use Sassnowski\Venture\AbstractWorkflow;
+use Sassnowski\Venture\WorkflowDefinition;
+
+class WorkflowWithDatabaseJob extends AbstractWorkflow
+{
+    public function definition(): WorkflowDefinition
+    {
+        return (new WorkflowDefinition)->addJob(
+            (new TestJobWithNonPublicProperties('foo', 'bar'))->onConnection('database')
+        );
+    }
+}

--- a/tests/WorkflowSerializationTest.php
+++ b/tests/WorkflowSerializationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+use Illuminate\Support\Facades\DB;
+use Sassnowski\Venture\Models\Workflow;
+use Stubs\TestJobWithNonPublicProperties;
+use Stubs\WorkflowWithDatabaseJob;
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertInstanceOf;
+
+uses(TestCase::class);
+
+it('can serialize job with protected and private properties', function () {
+    $workflow = WorkflowWithDatabaseJob::start('foo', 'bar');
+
+    assertInstanceOf(Workflow::class, $workflow);
+
+    assertCount(1, $jobs = DB::table('jobs')->get());
+
+    $payload = json_decode($jobs->first()->payload, true);
+
+    $job = unserialize($payload['data']['command']);
+
+    assertInstanceOf(TestJobWithNonPublicProperties::class, $job);
+    
+    assertEquals('foo', $job->getFoo());
+    assertEquals('bar', $job->getBar());
+});

--- a/tests/WorkflowSerializationTest.php
+++ b/tests/WorkflowSerializationTest.php
@@ -15,13 +15,21 @@ use Illuminate\Support\Facades\DB;
 use Sassnowski\Venture\Models\Workflow;
 use Stubs\TestJobWithNonPublicProperties;
 use Stubs\WorkflowWithDatabaseJob;
+use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertInstanceOf;
 
 uses(TestCase::class);
 
-it('can serialize job with protected and private properties', function () {
+beforeEach(function (): void {
+    if (! class_exists(CreateJobsTable::class)) {
+        artisan('queue:table');
+        artisan('migrate');
+    }
+});
+
+it('can serialize job with protected and private properties', function (): void {
     $workflow = WorkflowWithDatabaseJob::start('foo', 'bar');
 
     assertInstanceOf(Workflow::class, $workflow);


### PR DESCRIPTION
Closes #42

This PR adds a test for ensuring a job with `protected` and `private` properties can be properly serialized and unserialized from the `jobs` database table.