### PR TITLE
Add `php-cs-fixer` GitHub action

### DIFF
--- a/.github/workflows/fix-style.yml
+++ b/.github/workflows/fix-style.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: composer install
 
+      - name: Create php cs fixer cache directory
+        run: mkdir -p /.build/php-cs-fixer
+
       - name: Fix style
         run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes
 

--- a/.github/workflows/fix-style.yml
+++ b/.github/workflows/fix-style.yml
@@ -24,13 +24,8 @@ jobs:
       - name: Install dependencies
         run: composer install
 
-      - name: Create php cs fixer cache directory
-        run: |
-          sudo mkdir -p /.build/php-cs-fixer
-          sudo chmod 777 /.build/php-cs-fixer
-
       - name: Fix style
-        run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes
+        run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes --using-cache=no
 
       - name: Commit style fixes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/fix-style.yml
+++ b/.github/workflows/fix-style.yml
@@ -1,0 +1,33 @@
+name: fix-style
+
+on: [push]
+
+jobs:
+  cs-fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Fix style
+        run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes
+
+      - name: Commit style fixes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply php-cs-fixer changes

--- a/.github/workflows/fix-style.yml
+++ b/.github/workflows/fix-style.yml
@@ -25,7 +25,9 @@ jobs:
         run: composer install
 
       - name: Create php cs fixer cache directory
-        run: mkdir -p /.build/php-cs-fixer
+        run: |
+          sudo mkdir -p /.build/php-cs-fixer
+          sudo chmod 777 /.build/php-cs-fixer
 
       - name: Fix style
         run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes

--- a/tests/Stubs/WorkflowWithJob.php
+++ b/tests/Stubs/WorkflowWithJob.php
@@ -20,8 +20,8 @@ class WorkflowWithJob extends AbstractWorkflow
 {
     public function definition(): WorkflowDefinition
     {
-        return (new WorkflowDefinition)->addJob(
-            new TestJobWithHandle
+        return (new WorkflowDefinition())->addJob(
+            new TestJobWithHandle(),
         );
     }
 }

--- a/tests/VentureTest.php
+++ b/tests/VentureTest.php
@@ -23,18 +23,18 @@ use function PHPUnit\Framework\assertNotInstanceOf;
 
 uses(TestCase::class);
 
-afterEach(function () {
+afterEach(function (): void {
     Venture::useWorkflowModel(Workflow::class);
     Venture::useWorkflowJobModel(WorkflowJob::class);
 });
 
-it('can override workflow model', function () {
+it('can override workflow model', function (): void {
     Venture::useWorkflowModel(CustomWorkflowModel::class);
 
     assertInstanceOf(CustomWorkflowModel::class, WorkflowWithJob::start());
 });
 
-it('can override workflow job model', function () {
+it('can override workflow job model', function (): void {
     Venture::useWorkflowJobModel(CustomWorkflowJobModel::class);
 
     assertInstanceOf(Workflow::class, $workflow = WorkflowWithJob::start());
@@ -44,10 +44,10 @@ it('can override workflow job model', function () {
     assertNotInstanceOf(CustomWorkflowModel::class, $job->workflow);
 });
 
-it('can override workflow and job model', function () {
+it('can override workflow and job model', function (): void {
     Venture::useWorkflowModel(CustomWorkflowModel::class);
     Venture::useWorkflowJobModel(CustomWorkflowJobModel::class);
-    
+
     assertInstanceOf(CustomWorkflowModel::class, $workflow = WorkflowWithJob::start());
     assertCount(1, $jobs = $workflow->jobs()->get());
     assertInstanceOf(CustomWorkflowJobModel::class, $job = $jobs->first());


### PR DESCRIPTION
This PR adds a PHP CS Fixer GitHub action registered on the `push` event, so anytime you push, the style is auto-fixed with a commit.

Example: https://github.com/stevebauman/venture/commit/f5dce53ee91113560aa046d0a501ae79e435344d