### PR TITLE
Add method to configure definition conditionally

### DIFF
--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -18,6 +18,7 @@ use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Sassnowski\Venture\Exceptions\DuplicateJobException;
 use Sassnowski\Venture\Exceptions\DuplicateWorkflowException;
@@ -27,6 +28,7 @@ use Sassnowski\Venture\Models\Workflow;
 
 class WorkflowDefinition
 {
+    use Conditionable;
     protected array $jobs = [];
     protected DependencyGraph $graph;
     protected ?string $thenCallback = null;


### PR DESCRIPTION
This PR adds a `when` method to the `WorkflowDefinition` class to conditionally run a callback when configuring a definition. This allows users to conditionally add jobs to a workflow without having to litter definition with tons of if-statements.

This has been previously suggested in #2 where I initially declined the proposal. I have since then changed my mind on this and agree that this would be a useful addition. The method's API works slightly different than in the original PR but is otherwise pretty similar.

@morrislaptop I will add you as a co-author on this feature since you were the one who originally proposed it.

## Usage

```php
class MyWorkflow extends AbstractWorkflow
{
    public function __construct(private User $user)
    {
    }

    public function definition(): WorkflowDefinition
    {
        return Workflow::define('My conditional workflow')
            ->addJob(new JobThatShouldAlwaysRun())
            ->when($this->user->isProUser(), function (WorkflowDefinition $definition): void {
                $definition->addJob(new ProUserOnlyFeature());
            });
            // it's also possible to pass in a callable that returns a boolean as the condition
            ->when(fn (): bool => false, function (WorkflowDefinition $definition): void {
                $definition->addJob(new NeverGetsAdded());
            });
    }
}
```