### PR TITLE
[v4.x] Set `Workflow/WorkflowJob::getState()` methods to `protected`

### DIFF
--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -245,7 +245,7 @@ class Workflow extends Model
         $callback(...$args);
     }
 
-    private function getState(): WorkflowState
+    protected function getState(): WorkflowState
     {
         if (null === $this->state) {
             $this->state = app(Venture::$workflowState, ['workflow' => $this]);

--- a/src/Models/WorkflowJob.php
+++ b/src/Models/WorkflowJob.php
@@ -181,7 +181,7 @@ class WorkflowJob extends Model
         \dispatch($this->step());
     }
 
-    private function getState(): WorkflowJobState
+    protected function getState(): WorkflowJobState
     {
         if (null === $this->state) {
             $this->state = app(Venture::$workflowJobState, ['job' => $this]);


### PR DESCRIPTION
If we set the `getState()` method to `protected` instead of `private`, this will allow developers to create new workflow/workflow job states inside of their own `WorkflowState` implementation, or extended `DefaultWorkflowState`:

```php
class CustomWorkflowState extends DefaultWorkflowState
{
     public function someCustomState()
     {
         // ...
     }
}
```

```php
Venture::useWorkflowState(CustomWorkflowState::class);
```

```php
class Workflow extends VentureWorkflow
{
    public function someMethod()
    {
        return $this->getState()->someCustomState();
    }
}
```