### PR TITLE
Add ability to add jobs or workflows as a group

### DIFF
--- a/src/Exceptions/DuplicateGroupException.php
+++ b/src/Exceptions/DuplicateGroupException.php
@@ -15,10 +15,10 @@ namespace Sassnowski\Venture\Exceptions;
 
 use Exception;
 
-class UnresolvableDependenciesException extends Exception
+final class DuplicateGroupException extends Exception
 {
-    public static function groupDependency(string $groupName, string $nodeID): self
+    public static function forGroup(string $groupID): self
     {
-        return new self("The group [{$groupName}] references an unknown node [{$nodeID}]");
+        return new self("A group with the name {$groupID} already exists in this graph");
     }
 }

--- a/src/Exceptions/UnresolvableDependenciesException.php
+++ b/src/Exceptions/UnresolvableDependenciesException.php
@@ -17,8 +17,4 @@ use Exception;
 
 class UnresolvableDependenciesException extends Exception
 {
-    public static function groupDependency(string $groupName, string $nodeID): self
-    {
-        return new self("The group [{$groupName}] references an unknown node [{$nodeID}]");
-    }
 }

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -85,7 +85,7 @@ class DependencyGraph
     }
 
     /**
-     * @return array<int, array<int, Node>>
+     * @return array<string, array<int, Node>>
      */
     public function getGroups(): array
     {

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -78,6 +78,11 @@ class DependencyGraph
         $this->groups[$groupName] = $nodes;
     }
 
+    public function hasGroup(string $groupName): bool
+    {
+        return isset($this->groups[$groupName]);
+    }
+
     public function has(string $id): bool
     {
         return isset($this->graph[$id]) || isset($this->nestedGraphs[$id]);

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -59,28 +59,37 @@ class DependencyGraph
         }
     }
 
+    /**
+     * @param array<int, Dependency> $nodeIDs
+     */
     public function defineGroup(string $groupName, array $nodeIDs): void
     {
         if (isset($this->groups[$groupName])) {
             throw DuplicateGroupException::forGroup($groupName);
         }
 
-        $nodes = [];
-
-        foreach ($nodeIDs as $nodeID) {
-            if (!$this->has($nodeID)) {
-                throw UnresolvableDependenciesException::groupDependency($groupName, $nodeID);
-            }
-
-            $nodes[] = $this->get($nodeID);
-        }
-
-        $this->groups[$groupName] = $nodes;
+        $this->groups[$groupName] = $this->resolveDependencies($nodeIDs);
     }
 
     public function hasGroup(string $groupName): bool
     {
         return isset($this->groups[$groupName]);
+    }
+
+    /**
+     * @return array<int, Node>|null
+     */
+    public function getGroup(string $groupName): ?array
+    {
+        return $this->groups[$groupName] ?? null;
+    }
+
+    /**
+     * @return array<int, array<int, Node>>
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
     }
 
     public function has(string $id): bool

--- a/src/Graph/DependencyGraph.php
+++ b/src/Graph/DependencyGraph.php
@@ -77,7 +77,7 @@ class DependencyGraph
     }
 
     /**
-     * @return array<int, Node>|null
+     * @return null|array<int, Node>
      */
     public function getGroup(string $groupName): ?array
     {

--- a/src/Graph/GroupDependency.php
+++ b/src/Graph/GroupDependency.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+namespace Sassnowski\Venture\Graph;
+
+final class GroupDependency implements Dependency
+{
+    public function __construct(private readonly string $groupID)
+    {
+    }
+
+    public static function forGroup(string $groupID): self
+    {
+        return new self($groupID);
+    }
+
+    public function getID(DependencyGraph $graph): ?string
+    {
+        // @todo In the next major version, getID should allow returning an array as well
+        return $this->groupID;
+    }
+}

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -163,6 +163,15 @@ class WorkflowDefinition
     }
 
     /**
+     * Runs the provided callback on each element inside `$collection` and adds the
+     * resulting job or workflow to the workflow. This method will enumerate the
+     * id of each job or workflow by adding `_$i` to the end of it.
+     *
+     * If an explicit `$id` is provided, the new jobs or workflows will be registered
+     * as a group in the dependency graph. This group can then be depended on by
+     * another job or workflow by using `GroupDependency::forGroup($groupName)`, where
+     * `$groupName` is the `$id` that passed to this method.
+     *
      * @param array<array-key, mixed>|Collection<array-key, mixed> $collection
      * @param Closure(mixed): WorkflowableJob                      $factory
      * @param Delay                                                $delay

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -194,7 +194,7 @@ class WorkflowDefinition
             // We want to make sure we're resolving the id via the registered `StepIdGenerator`
             // if no explicit id was provided. Otherwise, this would potentially behave
             // differently than adding each job manually would.
-            $jobId = ($id ?: $this->resolveJobId($job)) . '_' . $i + 1;
+            $jobId = ($id ?: $this->resolveJobId($job)) . '_' . ($i + 1);
 
             if ($job instanceof AbstractWorkflow) {
                 $this->addWorkflow($job, $dependencies, $jobId);

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -173,7 +173,7 @@ class WorkflowDefinition
      * `$groupName` is the `$id` that passed to this method.
      *
      * @param array<array-key, mixed>|Collection<array-key, mixed> $collection
-     * @param Closure(mixed): WorkflowableJob                      $factory
+     * @param Closure(mixed): (AbstractWorkflow|WorkflowableJob)     $factory
      * @param Delay                                                $delay
      * @param array<int, string>                                   $dependencies
      */
@@ -483,7 +483,7 @@ class WorkflowDefinition
         }
     }
 
-    private function resolveJobId(WorkflowableJob $job): string
+    private function resolveJobId(WorkflowableJob|AbstractWorkflow $job): string
     {
         /** @var StepIdGenerator $stepIdGenerator */
         $stepIdGenerator = Container::getInstance()->make(StepIdGenerator::class);

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -194,7 +194,7 @@ class WorkflowDefinition
             // We want to make sure we're resolving the id via the registered `StepIdGenerator`
             // if no explicit id was provided. Otherwise, this would potentially behave
             // differently than adding each job manually would.
-            $jobId = ($id ?: $this->resolveJobId($job)).'_'.$i+1;
+            $jobId = ($id ?: $this->resolveJobId($job)) . '_' . $i + 1;
 
             if ($job instanceof AbstractWorkflow) {
                 $this->addWorkflow($job, $dependencies, $jobId);
@@ -213,7 +213,7 @@ class WorkflowDefinition
         // because when no id is provided, we really have no way of knowing what to call the
         // group since there is no guarantee that the provided factory function only returns
         // instances of the same class.
-        if ($id !== null && \count($jobIds) > 0) {
+        if (null !== $id && \count($jobIds) > 0) {
             $this->graph->defineGroup($id, $jobIds);
         }
 

--- a/src/WorkflowDefinition.php
+++ b/src/WorkflowDefinition.php
@@ -174,8 +174,8 @@ class WorkflowDefinition
      *
      * @param array<array-key, mixed>|Collection<array-key, mixed> $collection
      * @param Closure(mixed): (AbstractWorkflow|WorkflowableJob)     $factory
-     * @param Delay                                                $delay
-     * @param array<int, string>                                   $dependencies
+     * @param Delay              $delay
+     * @param array<int, string> $dependencies
      */
     public function each(
         array|Collection $collection,

--- a/tests/DependencyGraphTest.php
+++ b/tests/DependencyGraphTest.php
@@ -313,15 +313,15 @@ it('correctly resolves nested workflows in a group', function (): void {
         [
             new StaticDependency(TestJob2::class),
             new StaticDependency('::nested-workflow::'),
-        ]
+        ],
     );
     $graph1->addDependantJob(new TestJob5(), [GroupDependency::forGroup('::group::')], TestJob5::class);
 
     $dependencies = $graph1->getDependencies(TestJob5::class);
     expect($dependencies)->toEqual([
         TestJob2::class,
-        '::nested-workflow::.'.TestJob3::class,
-        '::nested-workflow::.'.TestJob4::class,
+        '::nested-workflow::.' . TestJob3::class,
+        '::nested-workflow::.' . TestJob4::class,
     ]);
 });
 

--- a/tests/DependencyGraphTest.php
+++ b/tests/DependencyGraphTest.php
@@ -314,3 +314,16 @@ it('throws an exception when trying the group contains job IDs that don\'t exist
     UnresolvableDependenciesException::class,
     'The group [::group-name::] references an unknown node [::unknown-job::]',
 );
+
+test('hasGroup returns true if a group with the given name exists', function (): void {
+    $graph = new DependencyGraph();
+    $graph->defineGroup('::group-name::', []);
+
+    expect($graph->hasGroup('::group-name::'))->toBeTrue();
+});
+
+test('hasGroup returns true if no group with the given name exists', function (): void {
+    $graph = new DependencyGraph();
+
+    expect($graph->hasGroup('::group-name::'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

This PR introduces two new features:

- An `each` method to add one job for each item of a collection without breaking the fluent interface
- The concept of a `group` and `GroupDependency`, so a job is able to depend on all jobs added by `each` without having to list them all manually

## Details

I frequently found myself in the position where I needed to add multiple instances of the same job to the workflow in a loop. Consider an example like this.

```php
class SendCampaignWorkflow extends AbstractWorkflow
{
    public function __construct(private readonly Campaign $campaign)
    {
    }

    public function definition(): WorkflowDefinition
    {
        $definition = $this->define('Send email campaign');
        
        foreach ($this->campaign->users as $i => $user) {
            $definition->addJob(
                new SpamUser($this->campaign, $user),
                id: 'spam_user_' . $i
            );
        }
        
        // Other stuff...
        
        return $definition;
    }
}
```

Here, I want to add a `SpamUser` job to the workflow for each of the `Campaign`'s `users`. Currently, this is very annoying because I have to break out of the fluent interface to some kind of loop. I also need to make sure to provide a unique id to each of these jobs by including the loop variable in the job id.

This gets even worse when I want to add a job that should only run once all of the `SpamUser` jobs have finished, as I would have to list each job id in the new job's `dependencies`.

One way to work around this would be to extract the `SpamUser` jobs into their own workflow and have the loop be there instead. Then I could simply add this new workflow as a nested workflow. This would also allow me to use the workflow as a dependency for other jobs, eliminating the need to enumerate each individual job id.

While this works, creating a whole separate workflow to essentially just wrap a `foreach` loop feels very clunky.

### Solution

With this PR, you would be able to use the new `each` method of the `WorkflowDefinition` to achieve the same thing, while still maintaining the ability to continue chaining.

```php
class SendCampaignWorkflow extends AbstractWorkflow
{
    public function __construct(private readonly Campaign $campaign)
    {
    }

    public function definition(): WorkflowDefinition
    {
        return $this->define('Send email campaign')
            ->each(
                $this->campaign->users,
                fn (User $user) => new SpamUser($this->campaign, $user),
            )
            ->addJob(new PatYourselfOnTheBack());
    }
}
```

The `each` method takes in a collection of items and a callback function. The callback function gets called for each item in the collection and should either return a `WorkflowableJob` or an `AbstractWorkflow`. Each job or nested workflow will then get added to the parent workflow.

Note that I didn't have to provide an explicit id anymore as the `each` method will fall back to using the registered `StepIdGenerator` internally. It will also enumerate each job id as we had done manually above. Similar to how `addJob` works, you're still able to provide an explicit ID, however. This id will still get enumerated to avoid duplicate job ids.

```php
$this->define('Send email campaign')
    ->each(
        $this->campaign->users,
        fn (User $user) => new SpamUser($this->campaign, $user),
        // Will get turned into "spam_users_1", "spam_users_2", etc
        id: 'spam_users'
    );
```

You're also able to provide a `name`, `delay`, as well as an array of `dependencies` to this method. All of these get set on each job.

### Groups

While this solves the issue of _defining_ these jobs, there's still no good way of _depending_ on this list of jobs. For this reason, this PR also adds the concept of `groups` to the `DependencyGraph`.

A group is essentially just a list of nodes (read: jobs), that you want to be able to address with a single name. This way, you can add a `GroupDependency` to a job and have it automatically resolve the correct dependencies.

The only place where a group is currently created, is when using the `each` method and defining an explicit `id`. The definition will then register all added jobs and workflows as a group in the dependency graph. The name of the group will be the provided `id`

```php
class SendCampaignWorkflow extends AbstractWorkflow
{
    public function __construct(private readonly Campaign $campaign)
    {
    }

    public function definition(): WorkflowDefinition
    {
        return $this->define('Send email campaign')
            ->each(
                $this->campaign->users,
                fn (User $user) => new SpamUser($this->campaign, $user),
                // Providing an explicit id defines a group for all jobs or workflows that were
                // added by the `each` call
                id: 'spam_users'
            )
            ->addJob(
                new PatYourselfOnTheBack(), 
                // We can then depend on the entire group by using a `GroupDependency`
                dependencies: [GroupDependency::forGroup('spam_users')]
            );
    }
}
```

A `GroupDependency` will also correctly resolve the required dependencies for any nested workflows that might have been added to the parent workflow.
