### PR TITLE
Feature | Prunable

### DIFF
--- a/config/venture.php
+++ b/config/venture.php
@@ -16,6 +16,11 @@ return [
     'jobs_table' => 'workflow_jobs',
 
     /*
+     * The number of days to keep when pruning workflows.
+     */
+    'prune_days' => 3,
+
+    /*
      * The class that should be used to generate an id for a workflow
      * job if no explicit id was provided. In most cases, you won't have
      * to change this.

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Collection;
@@ -46,6 +47,8 @@ use Throwable;
  */
 class Workflow extends Model
 {
+    use Prunable;
+
     /**
      * @var array<int, string>
      */
@@ -251,5 +254,10 @@ class Workflow extends Model
     private function serializer(): WorkflowJobSerializer
     {
         return Container::getInstance()->make(WorkflowJobSerializer::class);
+    }
+
+    public function prunable()
+    {
+        return static::where('created_at', '<=', now()->subDays(config('venture.prune_days')));
     }
 }

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -258,6 +258,6 @@ class Workflow extends Model
 
     public function prunable()
     {
-        return static::where('created_at', '<=', now()->subDays(config('venture.prune_days')));
+        return static::where('created_at', '<=', now()->subDays(config('venture.prune_days', 7)));
     }
 }

--- a/tests/PruneTest.php
+++ b/tests/PruneTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Sassnowski\Venture\Models\Workflow;
+
+use function Pest\Laravel\assertModelExists;
+use function Pest\Laravel\assertModelMissing;
+
+/**
+ * Copyright (c) 2023 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ksassnowski/venture
+ */
+
+ uses(TestCase::class);
+
+ it('can prune Workflow models and WorkflowJob models are cascade deleted', function (): void {
+    Carbon::setTestNow('2024-02-28 11:11:00');
+    config()->set('venture.prune_days', 3);
+
+    // Create two workflows, one to be pruned and one that's not within the prune window.
+
+    $pruneWorkflow = createWorkflow();
+    $pruneWorkflowJob1 = createWorkflowJob($pruneWorkflow, ['failed_at' => now()]);
+    $pruneWorkflowJob2 = createWorkflowJob($pruneWorkflow, ['finished_at' => now()]);
+
+    expect($pruneWorkflow->created_at)->toEqual(now());
+    expect($pruneWorkflow->jobs)->toHaveCount(2);
+
+    $this->travel(1)->day();
+
+    $workflow = createWorkflow();
+    $workflowJob1 = createWorkflowJob($workflow);
+
+    expect($workflow->created_at)->toEqual(now());
+    expect($workflow->jobs)->toHaveCount(1);
+
+    // There should be 2 workflows and 3 workflow jobs.
+
+    expect(DB::table(config('venture.workflow_table'))->count())->toEqual(2);
+    expect(DB::table(config('venture.jobs_table'))->count())->toEqual(3);
+
+    // Travel to exactly three days from the start of the test, which is the number of days
+    // the prune_days config is set at.
+
+    $this->travelTo('2024-03-02 11:11:00');
+
+    // Run the prune artisan command and expect the $pruneWorkflow and its jobs to be deleted
+    // but the other workflow is kept as it was created within the prune window.
+
+    $this->artisan('model:prune', ['--model' => Workflow::class]);
+
+    assertModelMissing($pruneWorkflow);
+    assertModelMissing($pruneWorkflowJob1);
+    assertModelMissing($pruneWorkflowJob2);
+
+    assertModelExists($workflow);
+    assertModelExists($workflowJob1);
+
+    expect(DB::table(config('venture.workflow_table'))->count())->toEqual(1);
+    expect(DB::table(config('venture.jobs_table'))->count())->toEqual(1);
+ });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,6 +54,7 @@ class TestCase extends OrchestraTestCase
             'driver' => 'sqlite',
             'database' => ':memory:',
             'prefix' => '',
+            'foreign_key_constraints' => true,
         ]);
 
         config()->set('venture.workflow_table', 'workflows');


### PR DESCRIPTION
Added the `Prunable` trait to the Workflow model, allowing a scheduled command to keep these tables size down. I have also added a new config value for how for how many days we should keep the Workflow models for when pruning.

I am happy to change the config property name, and the default values to something more suitable if required.

In our application, we'll be running lots of Workflows, and because the the callbacks are serialised, we found we had to change the database column from a `text` to a `longtext` to allow bigger workflows. Keeping these Venture workflow job without pruning will result in our database getting bigger and bigger. With Prunable we can help keep our database size down, as for our purposes, once it's been a week we no longer care about the workflow as these would've been processed by then.