### PR TITLE
Fix | Fixed WorkflowEventSubscriber callbacks running on non WorkflowJob jobs

### DIFF
--- a/src/WorkflowEventSubscriber.php
+++ b/src/WorkflowEventSubscriber.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Sassnowski\Venture;
 
 use Closure;
-use Illuminate\Contracts\Events\Dispatcher;
+use function event;
 use Illuminate\Queue\Events\JobFailed;
+use Sassnowski\Venture\WorkflowableJob;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Contracts\Events\Dispatcher;
 use Sassnowski\Venture\Actions\HandlesFailedJobs;
 use Sassnowski\Venture\Actions\HandlesFinishedJobs;
-use function event;
 
 class WorkflowEventSubscriber
 {
@@ -97,6 +98,12 @@ class WorkflowEventSubscriber
         JobProcessing|JobProcessed|JobFailed $event,
         Closure $callback,
     ): void {
+        $jobName = $event->job->payload()['data']['commandName'] ?? null;
+
+        if (is_object($jobName) && !isset(class_implements($jobName)[WorkflowableJob::class])) {
+            return;
+        }
+
         $jobInstance = $this->jobExtractor->extractWorkflowJob($event->job);
 
         if (null !== $jobInstance) {


### PR DESCRIPTION
Fixes #90 
Fixes #65 

Using @stevebauman suggestion, when subscribing to events in WorkflowSubscriber, if the incoming event is not a WorkflowJob job then we return early, and so it will not try to extract the WorkflowJob from the event using the Base64WorkflowSerializer.

I'm not sure what tests I can write sorry. I have testing this in both the [minimal repository](https://github.com/simple-hacker/venture-sync-driver-error) I made in the issue, and in my production app, and can confirm these are now working again, as well as the Venture test suite is passing again.

Happy to discuss how I can write the test here to confirm it's working properly.