### PR TITLE
Fix | Added `down` method to migration class

### DIFF
--- a/database/migrations/create_workflow_tables.php.stub
+++ b/database/migrations/create_workflow_tables.php.stub
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration
+return new class() extends Migration
 {
     public function up(): void
     {

--- a/database/migrations/create_workflow_tables.php.stub
+++ b/database/migrations/create_workflow_tables.php.stub
@@ -4,8 +4,11 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class() extends Migration {
-    public function up()
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
     {
         Schema::create(config('venture.workflow_table'), function (Blueprint $table) {
             $table->id();
@@ -42,5 +45,14 @@ return new class() extends Migration {
                 ->onUpdate('cascade')
                 ->onDelete('cascade');
         });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists(config('venture.jobs_table'));
+        Schema::dropIfExists(config('venture.workflow_table'));
     }
 };

--- a/database/migrations/create_workflow_tables.php.stub
+++ b/database/migrations/create_workflow_tables.php.stub
@@ -4,8 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class() extends Migration
-{
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create(config('venture.workflow_table'), function (Blueprint $table) {

--- a/database/migrations/create_workflow_tables.php.stub
+++ b/database/migrations/create_workflow_tables.php.stub
@@ -4,10 +4,8 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
-    /**
-     * Run the migrations.
-     */
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create(config('venture.workflow_table'), function (Blueprint $table) {
@@ -47,9 +45,6 @@ return new class extends Migration {
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists(config('venture.jobs_table'));


### PR DESCRIPTION
The migration class was missing the `down` method, preventing a proper rollback of the migration.

This PR adds the missing method and adds some standard Laravel annotations and type hints.